### PR TITLE
(fix) compatibility with gedit >= 44

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+install:
+	@mkdir -p ~/.local/share/gedit/plugins 
+	@cp autosave.plugin autosave.py ~/.local/share/gedit/plugins -v

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
 install:
-	@mkdir -p ~/.local/share/gedit/plugins 
+	@mkdir -p ~/.local/share/gedit/plugins
 	@cp autosave.plugin autosave.py ~/.local/share/gedit/plugins -v
+
+uninstall:
+	@rm -fv ~/.local/share/gedit/plugins/autosave.{plugin,py}

--- a/autosave.py
+++ b/autosave.py
@@ -15,12 +15,11 @@
 
 import datetime
 
-from gi.repository import GObject, Gedit, Gtk, Gio, Gdk
+from gi.repository import GObject, Gedit, Gio, Gdk
 from pathlib import Path
 
 def on_key_press(widget, event):
   global Ctrl_S
-  print('ctrl-s')
   if event.state == Gdk.ModifierType.CONTROL_MASK and event.keyval == Gdk.KEY_s:
       Ctrl_S = True
 
@@ -46,6 +45,7 @@ class ASWindowActivatable(GObject.Object, Gedit.WindowActivatable):
   def on_unfocused(self, *args):
     global Ctrl_S
     if Ctrl_S:
+      Ctrl_S = False
       # skip to user specified file name
       return
 
@@ -67,7 +67,6 @@ class ASWindowActivatable(GObject.Object, Gedit.WindowActivatable):
 
       # save the document
       Gedit.commands_save_document(self.window, doc)
-      Ctrl_S = False
 
 
 class ASViewActivatable(GObject.Object, Gedit.ViewActivatable):

--- a/autosave.py
+++ b/autosave.py
@@ -35,7 +35,7 @@ class ASWindowActivatable(GObject.Object, Gedit.WindowActivatable):
     super().__init__()
 
   def do_activate(self):
-    self.id_unfocus = self.window.connect('focus-out-event', self.on_unfocused, GObject.PRIORITY_DEFAULT)
+    self.id_unfocus = self.window.connect('focus-out-event', self.on_unfocused)
     self.id_ctrl_s = self.window.connect("key-press-event", on_key_press)
 
   def do_deactivate(self):

--- a/autosave.py
+++ b/autosave.py
@@ -4,12 +4,12 @@
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
@@ -31,7 +31,7 @@ class ASWindowActivatable(GObject.Object, Gedit.WindowActivatable):
   def on_unfocused(self, *args):
     for d in self.window.get_unsaved_documents():
       f = d.get_file()
-      if d.get_modified() and not f.is_readonly() and not d.is_untitled():
+      if d.get_modified() and not f.is_readonly() and f.get_location() is not None:
         Gedit.commands_save_document(self.window, d)
 
 
@@ -59,7 +59,7 @@ class ASViewActivatable(GObject.Object, Gedit.ViewActivatable):
 
   def on_changed(self, *args):
     f = self.doc.get_file()
-    if f.is_readonly() or self.doc.is_untitled():
+    if f.is_readonly() or f.get_location() is None:
       return
     self.remove_timeout()
     self.timeout = GObject.timeout_add(


### PR DESCRIPTION
Your fabulous plugin now works seamlessly again after addressing the removal of the `gedit_document_is_untitled()` function in `gedit 44`, as mentioned [here](https://gedit-technology.net/developer-docs/gedit/api-breaks.html).

In addition, it will now save untitled files automatically when the window loses focus!